### PR TITLE
Don't create postgres related items if postgres is disabled.

### DIFF
--- a/templates/postgres/deployment.yaml
+++ b/templates/postgres/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled -}}
 {{- $fullName := include "lemmy.fullname" . -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -112,3 +113,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/templates/postgres/pvc.yaml
+++ b/templates/postgres/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled -}}
 {{- $fullName := include "lemmy.fullname" . -}}
 {{- with .Values.postgres.storage -}}
 {{- if eq .kind "persistentVolumeClaim" -}}
@@ -17,3 +18,4 @@ spec:
       storage: {{ .pvc.size }}
 {{- end -}}
 {{- end }}
+{{- end -}}

--- a/templates/postgres/service.yaml
+++ b/templates/postgres/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled -}}
 {{ with .Values.postgres }}
 apiVersion: v1
 kind: Service
@@ -16,3 +17,4 @@ spec:
     {{- include "lemmy.selectorLabels" $ | nindent 4 }}
     app.kubernetes.io/component: postgres
 {{ end }}
+{{- end -}}


### PR DESCRIPTION
Hey I noticed that the current chart still creates the deployment and service when postgres is disabled via values this MR disables the creation.